### PR TITLE
Added kill sensory neuron (#2)

### DIFF
--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -34,6 +34,8 @@ std::string sensorName(Sensor sensor)
     case SIGNAL0: return "signal 0"; break;
     case SIGNAL0_FWD: return "signal 0 fwd"; break;
     case SIGNAL0_LR: return "signal 0 LR"; break;
+    case KILLS: return "kills"; break;
+    case SELF_KILLS: return "self kills"; break;
     case GENETIC_SIM_FWD: return "genetic similarity fwd"; break;
     default: assert(false); break;
     }
@@ -91,6 +93,8 @@ std::string sensorShortName(Sensor sensor)
     case SIGNAL0: return "Sg"; break;
     case SIGNAL0_FWD: return "Sfd"; break;
     case SIGNAL0_LR: return "Slr"; break;
+    case KILLS: return "Kls"; break;
+    case SELF_KILLS: return "Sks"; break;
     case GENETIC_SIM_FWD: return "Gen"; break;
     default: assert(false); break;
     }

--- a/src/executeActions.cpp
+++ b/src/executeActions.cpp
@@ -137,6 +137,7 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
                 if (indiv2.alive) {
                     assert((indiv.loc - indiv2.loc).length() == 1);
                     peeps.queueForDeath(indiv2);
+                    ++indiv.kills;
                 }
             }
         }

--- a/src/getSensor.cpp
+++ b/src/getSensor.cpp
@@ -326,6 +326,27 @@ float Indiv::getSensor(Sensor sensorNum, unsigned simStep) const
         // Sense signal0 density along an axis perpendicular to last movement direction
         sensorVal = getSignalDensityAlongAxis(0, loc, lastMoveDir.rotate90DegCW());
         break;
+    case Sensor::KILLS:
+    {
+        // Returns amount of kills by nearby individuals divided by the total kill count
+        unsigned countKills = 0;
+        Coord center = loc;
+
+        auto f = [&](Coord tloc) {
+            if (grid.isOccupiedAt(tloc)) {
+                const Indiv &indiv2 = peeps.getIndiv(tloc);
+                countKills += indiv2.kills;
+            }
+        };
+
+        visitNeighborhood(center, p.populationSensorRadius, f);
+        sensorVal = (float)countKills / murderCount;
+        break;
+    }
+    case Sensor::SELF_KILLS:
+        // Returns self kills divided by the total kill count
+        sensorVal = (float)kills / murderCount;
+        break;
     case Sensor::GENETIC_SIM_FWD:
     {
         // Return minimum sensor value if nobody is alive in the forward adjacent location,

--- a/src/indiv.cpp
+++ b/src/indiv.cpp
@@ -17,6 +17,7 @@ void Indiv::initialize(uint16_t index_, Coord loc_, const Genome &&genome_)
     //birthLoc = loc_;
     grid.set(loc_, index_);
     age = 0;
+    kills = 0;
     oscPeriod = 34; // ToDo !!! define a constant
     alive = true;
     lastMoveDir = Dir::random8();

--- a/src/indiv.h
+++ b/src/indiv.h
@@ -15,6 +15,7 @@ namespace BS {
 
 struct Indiv {
     bool alive;
+    uint16_t kills;
     uint16_t index; // index into peeps[] container
     Coord loc;   // refers to a location in grid[][]
     Coord birthLoc;

--- a/src/sensors-actions.h
+++ b/src/sensors-actions.h
@@ -56,6 +56,8 @@ enum Sensor {
     SIGNAL0_FWD,       // W strength of signal0 in the forward-reverse axis
     SIGNAL0_LR,        // W strength of signal0 in the left-right axis
     NUM_SENSES,        // <<------------------ END OF ACTIVE SENSES MARKER
+    KILLS,             // W number of kills of nearby individuals
+    SELF_KILLS,        // W number of kills of self
 };
 
 

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -29,6 +29,7 @@ RunMode runMode = RunMode::STOP;
 Grid grid;        // The 2D world where the creatures live
 Signals signals;  // A 2D array of pheromones that overlay the world grid
 Peeps peeps;      // The container of all the individuals in the population
+unsigned murderCount;    // This counts the total kills
 ImageWriter imageWriter; // This is for generating the movies
 
 // The paramManger maintains a private copy of the parameter values, and a copy
@@ -130,7 +131,7 @@ void simulator(int argc, char **argv)
 
     runMode = RunMode::RUN;
     while (runMode == RunMode::RUN && generation < p.maxGenerations) { // generation loop
-        unsigned murderCount = 0; // for reporting purposes
+        murderCount = 0;
         for (unsigned simStep = 0; simStep < p.stepsPerGeneration; ++simStep) {
 
             // multithreaded loop: index 0 is reserved, start at 1

--- a/src/simulator.h
+++ b/src/simulator.h
@@ -42,6 +42,7 @@ extern const Params &p; // read-only simulator config params
 extern Grid grid;  // 2D arena where the individuals live
 extern Signals signals;  // pheromone layers
 extern Peeps peeps;   // container of all the individuals
+extern unsigned murderCount;  // This counts the total kills
 extern void simulator(int argc, char **argv);
 
 // Feeds in-bounds Coords to a function: given a center location and a radius, this


### PR DESCRIPTION
Added two new sensors, KILLS & SELF_KILLS.
KILLS returns the total number of kills of individuals in the area divided by the total kills.
SELF_KILLS returns the current individual's kills divided by the total kills.

These are both disabled by default, because the KILL_FORWARD action is and you could probably
get rid of SELF_KILLS since it's not as useful.

I've also made the murderCount variable in simulator.cpp global so it can be accessed in getSensor.cpp.